### PR TITLE
支持密钥方式登录服务器

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -33,10 +33,11 @@ function store(options) {
     window.localStorage.port = options.port
     window.localStorage.username = options.username
     window.localStorage.password = options.password
+    window.localStorage.privatekey = options.privatekey
 }
 
 function check() {
-    var result = $("#host").val() && $("#port").val() && $("#username").val() && $("#password").val()
+    var result = $("#host").val() && $("#port").val() && $("#username").val() //&& $("#password").val()
     if (result) {
         var spans = $("fieldset").find("span")
         // do not check the password
@@ -55,7 +56,8 @@ function connect() {
         host: $("#host").val(),
         port: $("#port").val(),
         username: $("#username").val(),
-        password: $("#password").val()
+        password: $("#password").val(),
+        privatekey: $("#privatekey").val()
     }
     if (remember) {
         store(options)

--- a/static/js/ws.js
+++ b/static/js/ws.js
@@ -49,7 +49,8 @@ WSSHClient.prototype.sendInitData = function (options) {
         hostname: options.host,
         port: options.port,
         username: options.username,
-        password: options.password
+        password: options.password,
+        privatekey: options.privatekey
     }
     this._connection.send(JSON.stringify({"tp": "init", "data": data}))
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,11 @@
             </div>
             <div class="pure-item">
                 <label for="password">Password</label>
-                <input id="password" name="password" type="password" placeholder="Password">
+                <input id="password" name="password" type="password" placeholder="Server Password or Private Key Password">
+            </div>
+            <div class="pure-item">
+                <label for="privatekey">Private Key</label>
+                <textarea rows="5" cols="20" id="privatekey" name="privatekey" placeholder="Private Key"></textarea>
             </div>
             <label for="remember" class="pure-checkbox">
                 <input id="remember" type="checkbox"> Remember me
@@ -48,7 +52,7 @@
             {name: "host", type: "ip"},
             {name: "port", type: "port"},
             {name: "username", type: "username"},
-            {name: "password", type: "password"},
+            //{name: "password", type: "password"},
         ]);
     })
 </script>


### PR DESCRIPTION
加了用私钥登录验证的方式：
1. 前端注释了password验证，增加私钥文本框；
2. 私钥可以无密和有密：当其文本框存在值便采用其登录，私钥密码是password值；
3. paramiko建立连接时首先判断是否可以采用私钥登录。
