### PR TITLE
check is password mode

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -39,7 +39,7 @@ class Bridge(object):
         return pkey
 
     def isPassword(self, data):
-        return data.get("ispwd", True)
+        return data.get("ispwd", 'true') == 'true'
 
     def open(self, data={}):
         self.ssh.set_missing_host_key_policy(


### PR DESCRIPTION
后台判断是否是密码模式处，判断有问题。
data.get('ispwd')返回的是str格式。
当前台返回'false'时，判断函数返回'false'，导致open函数if判断错误。